### PR TITLE
Use `expose` instead of `ports`

### DIFF
--- a/docker-compose.vite.yaml
+++ b/docker-compose.vite.yaml
@@ -5,8 +5,8 @@
 services:
   web:
     # ports are a list of exposed *container* ports
-    ports:
-      - "${VITE_PORT:-3000}"
+    expose:
+      - 3000
     environment:
       - HTTP_EXPOSE=${DDEV_ROUTER_HTTP_PORT}:80,${DDEV_MAILHOG_PORT}:8025,3001:${VITE_PORT:-3000}
       - HTTPS_EXPOSE=${DDEV_ROUTER_HTTPS_PORT}:80,${DDEV_MAILHOG_HTTPS_PORT}:8025,${VITE_PORT:-3000}:${VITE_PORT:-3000}


### PR DESCRIPTION
If you use `ports`, the project will bind the port to the host, which is unnecessary because you have it all set up to go through the router with HTTP_EXPOSE and HTTPS_EXPOSE. With `ports` you can run only one project without hitting a port conflict.